### PR TITLE
Point to our fork of django-oauth2-provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 django-oauth-plus>=2.2.1
 oauth2>=1.5.211
-django-oauth2-provider>=0.2.4
+
+# Point to EdX's fork of django-oauth2-provider.  If we install the upstream version of this library,
+# the upstream version can shadow our fork.
+-e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-5#egg=django-oauth2-provider

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ url = 'https://github.com/jpadilla/django-rest-framework-oauth'
 author = 'José Padilla'
 author_email = 'hello@jpadilla.com'
 license = 'BSD'
-install_requires = open('requirements.txt').read().split('\n')
+install_requires = [
+    line for line in open('requirements.txt').read().split('\n')
+    if not line.startswith("-e") and not line.startswith("#")
+]
 
 
 # This command has been borrowed from


### PR DESCRIPTION
Prereq for the DRF upgrade.  The issue is that django-rest-framework-oauth includes includes "django-oauth2-provider" in its requirements.  This causes the upstream version of "django-oauth2-provider" to be installed, shadowing our fork.

@macdiesel please review.
