### PR TITLE
Remove unused install_requires method.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,6 @@ url = 'https://github.com/jpadilla/django-rest-framework-oauth'
 author = 'José Padilla'
 author_email = 'hello@jpadilla.com'
 license = 'BSD'
-install_requires = [
-    line for line in open('requirements.txt').read().split('\n')
-    if not line.startswith("-e") and not line.startswith("#")
-]
 
 
 # This command has been borrowed from


### PR DESCRIPTION
The method remained due to a poor merge in https://github.com/edx/django-rest-framework-oauth/pull/4 - this PR removes it.